### PR TITLE
feat: IPv6 dual-stack support, accept both client IPs, help command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ pubspec.lock
 .DS_Store
 
 *.exe
+
+# Test coverage output
+coverage/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,12 @@
   - Added `help` / `?` command listing all commands and their usage.
   - `connect` accepts an optional `addressType` to force the IP family;
     added `myIPs()` returning both families' addresses.
+  - Fixed `list accepts` parsing to split on the last `:` so IPv6 addresses
+    (which contain `:`) are no longer dropped.
 - `utils`: added `normalizeIpAddress` and `isIPv6Address` helpers.
+- Tests: added IPv6/dual-stack coverage (`normalizeIpAddress`/`isIPv6Address`,
+  `iptables` argument validation, and an end-to-end `myIPs`/`accept .`/
+  `unaccept .` dual-stack client/server test).
 
 ## 1.0.12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+## 1.1.0
+
+- IPv6 support (dual-stack):
+  - `GatekeeperServer`: now binds `InternetAddress.anyIPv6` with `v6Only: false`
+    by default, accepting both IPv4 and IPv6 connections. IPv4-mapped IPv6
+    remote addresses (`::ffff:1.2.3.4`) are normalized to plain IPv4.
+  - `GatekeeperIpTables`: manages IPv6 rules via `ip6tables` (optional; skipped
+    gracefully when not installed):
+    - `accept`/`unaccept` select `iptables` or `ip6tables` from the address
+      family.
+    - `block`/`unblock` apply to both `iptables` and `ip6tables`.
+    - Listings merge results from both families.
+- `gatekeeper_client`:
+  - `accept . <port>` now whitelists **both** the client's IPv4 and IPv6
+    addresses (the missing family is discovered via an auxiliary connection),
+    and prints the concrete IP(s) accepted. `unaccept .` removes both.
+  - Added `help` / `?` command listing all commands and their usage.
+  - `connect` accepts an optional `addressType` to force the IP family;
+    added `myIPs()` returning both families' addresses.
+- `utils`: added `normalizeIpAddress` and `isIPv6Address` helpers.
+
 ## 1.0.12
 
 - `bin/gatekeeper_client.dart`:

--- a/README.md
+++ b/README.md
@@ -11,8 +11,17 @@
 [![License](https://img.shields.io/github/license/gmpassos/gatekeeper?logo=open-source-initiative&logoColor=green)](https://github.com/gmpassos/gatekeeper/blob/master/LICENSE)
 
 `gatekeeper` is a Dart package for managing TCP ports, offering a manager, server, and client for seamless control. You
-can list, block, and unblock ports programmatically, through inter-process communication (IPC), or remotely, providing a
-flexible and efficient solution for port management.
+can list, block, and unblock ports — and allow-list specific source addresses (IPv4 **and** IPv6) — programmatically,
+through inter-process communication (IPC), or remotely, providing a flexible and efficient solution for port management.
+
+- **Dual-stack (IPv4 + IPv6):** rules are applied with `iptables` for IPv4 and `ip6tables` for IPv6.
+- **Secure remote control:** the server/client protocol authenticates with an access key and uses an encrypted session.
+- **Address allow-listing:** open a blocked port only to specific source addresses.
+
+> **Note:** the `GatekeeperIpTables` driver runs `iptables`/`ip6tables`, so it requires **Linux** and **root**
+> privileges (run the process as `root`, or via `sudo`). `ip6tables` is optional — when it is not installed, IPv6
+> operations are skipped gracefully. For trying the API/CLI on other platforms, use the in-memory mock
+> (`GatekeeperMock`, or `--mock` on the CLI).
 
 ## Usage
 
@@ -23,7 +32,7 @@ import 'package:gatekeeper/gatekeeper_iptables.dart';
 
 void main() async {
   var gatekeeper = Gatekeeper(
-    driver: GatekeeperIpTables(), // Use `iptables` to handle ports.
+    driver: GatekeeperIpTables(), // Use `iptables`/`ip6tables` to handle ports.
     allowedPorts: {2080, 2443}, // Only handle ports 2080 and 2443.
   );
 
@@ -31,17 +40,24 @@ void main() async {
   var blockedTCPPorts = await gatekeeper.listBlockedTCPPorts();
   print("-- Blocked TCP ports: $blockedTCPPorts");
 
-  // Block port 2222:
+  // Block port 2080:
   var blocked = await gatekeeper.blockTCPPort(2080);
   print("-- Blocked 2080: $blocked");
 
-  // Unblock port 2222:
+  // Allow a specific source address on the blocked port (IPv4 or IPv6):
+  await gatekeeper.acceptAddressOnTCPPort('192.168.0.10', 2080);
+  await gatekeeper.acceptAddressOnTCPPort('2001:db8::1', 2080);
+
+  // List accepted addresses:
+  print("-- Accepted: ${await gatekeeper.listAcceptedAddressesOnTCPPorts()}");
+
+  // Unblock port 2080:
   var unblocked = await gatekeeper.unblockTCPPort(2080);
   print("-- Unblocked 2080: $unblocked");
 
   // Try to block a not allowed port:
   var failedBlock = await gatekeeper.blockTCPPort(8080);
-  print("-- Failed block of 2080: $failedBlock");
+  print("-- Failed block of 8080: $failedBlock");
 }
 ```
 
@@ -53,21 +69,64 @@ Activate the `gatekeeper` commands:
 dart pub global activate gatekeeper
 ```
 
-### gatekeeper
+### gatekeeper (server)
 
 To run a `GatekeeperServer` listening on port `2243` and managing ports `2221,2222,2223`:
 
 ```bash
-gatekeeper --port 2243 --allowed-ports 2221,2222,2223
+gatekeeper --port 2243 --access-key <ACCESS_KEY> --allowed-ports 2221,2222,2223
 ```
+
+The access key is **required** and must be at least 32 characters long. If `--access-key` is omitted, the server prompts
+for it (use `--access-key -` or `--access-key .` to read it from `stdin`). The server binds dual-stack by default, so it
+accepts both IPv4 and IPv6 connections.
+
+Options:
+
+| Option | Description |
+|---|---|
+| `--port <port>` | **Required.** Port to listen on. |
+| `--access-key <key>` | **Required.** Access key (length ≥ 32). `-` / `.` reads from `stdin`. |
+| `--allowed-ports <p1,p2,...>` | Ports this server is allowed to manage. |
+| `--allow-all-ports` | Allow managing any port (overrides `--allowed-ports`). |
+| `--mock` | Use the in-memory mock driver instead of `iptables` (for testing). |
+| `--verbose` | Verbose logging. |
+
+> Because it manages `iptables`/`ip6tables`, the server must run on Linux as `root` (e.g. `sudo gatekeeper ...`),
+> unless `--mock` is used.
 
 ### gatekeeper_client
 
-To connect to a `GatekeeperServer` on port `2243`:
+To connect to a `GatekeeperServer` on host `server-host` port `2243`:
 
 ```bash
-gatekeeper_client server-host 2243
+gatekeeper_client server-host 2243 --access-key <ACCESS_KEY>
 ```
+
+Once connected, it opens an interactive prompt. Available commands (type `help` or `?` to list them):
+
+| Command | Description |
+|---|---|
+| `list` \| `ls` \| `l` `[ports\|accepts\|all]` | List blocked ports and/or accepted addresses (default: `all`). |
+| `block <port>` | Block a TCP port (applied to both IPv4 and IPv6). |
+| `unblock <port>` | Unblock a TCP port (IPv4 and IPv6). |
+| `accept <address\|.> <port>` | Allow a source address on a port. `.` means **this client** — whitelists **both** its IPv4 and IPv6 address. |
+| `unaccept <address\|.> [port]` | Remove an accepted address (all ports if omitted). `.` means this client. |
+| `myip` \| `my ip` | Show this client's IP as seen by the server. |
+| `help` \| `?` | Show the list of commands. |
+| `exit` | Disconnect and quit. |
+
+For example, to open blocked port `22` to the machine you are connecting from (both IPv4 and IPv6):
+
+```text
+> accept . 22
+-- Accepted IPv4 `203.0.113.5` on port 22: true
+-- Accepted IPv6 `2001:db8::1` on port 22: true
+-- Accepted IPs on port 22: 203.0.113.5, 2001:db8::1
+```
+
+> To resolve both families, the client briefly opens an auxiliary connection over the missing family, so the server must
+> be reachable over both IPv4 and IPv6 for both to be whitelisted; otherwise only the reachable family is used.
 
 #### Configuration (`.gatekeeper` directory)
 

--- a/bin/gatekeeper_client.dart
+++ b/bin/gatekeeper_client.dart
@@ -51,6 +51,7 @@ void main(List<String> argsOrig) async {
       '-- Logged to `GatekeeperServer` @ $host:$port [${login.serverVersion}]');
 
   print('------------------------------------------------------');
+  print('Type `help` or `?` to list the available commands.');
 
   while (client.isConnected) {
     stdout.write('> ');

--- a/lib/src/gatekeeper_client.dart
+++ b/lib/src/gatekeeper_client.dart
@@ -50,12 +50,29 @@ class GatekeeperClient {
 
   /// Connects to the Gatekeeper server.
   ///
+  /// - [addressType]: If provided, resolves [host] to this IP family
+  ///   ([InternetAddressType.IPv4] or [InternetAddressType.IPv6]) and connects
+  ///   to the resolved address, forcing the connection over that family. If
+  ///   `null` (default), connects using the platform's default resolution.
+  ///
   /// Returns a [Future] that completes with `true` if the connection was successful,
   /// or `false` if already connected.
-  Future<bool> connect() async {
+  Future<bool> connect({InternetAddressType? addressType}) async {
     if (isConnected) return false;
-    var socket = _socket = await Socket.connect(host, port);
 
+    Socket socket;
+    if (addressType != null) {
+      var addresses = await InternetAddress.lookup(host, type: addressType);
+      if (addresses.isEmpty) {
+        throw SocketException("No $addressType address for host `$host`",
+            address: null);
+      }
+      socket = await Socket.connect(addresses.first, port);
+    } else {
+      socket = await Socket.connect(host, port);
+    }
+
+    _socket = socket;
     socket.listen(_onData, cancelOnError: true, onDone: _onClose);
 
     return true;
@@ -354,7 +371,70 @@ class GatekeeperClient {
     var match = RegExp(r'ip:\s+(\S+)').firstMatch(response);
     var ip = match?.group(1);
 
-    return ip;
+    return ip != null ? normalizeIpAddress(ip) : null;
+  }
+
+  /// Retrieves both the IPv4 and IPv6 addresses of this client as seen by the
+  /// remote server.
+  ///
+  /// The current connection only reveals the address of the family it was
+  /// established over. To discover the other family, an auxiliary connection
+  /// is opened (forced to that family, authenticated with the same access key)
+  /// and queried with [myIP].
+  ///
+  /// A slot is `null` when that family could not be determined (e.g. the server
+  /// is not reachable over it, or [host] is a literal address of the other
+  /// family).
+  Future<({String? ipv4, String? ipv6})> myIPs() async {
+    String? ipv4;
+    String? ipv6;
+
+    // Current connection: classify its server-visible address by family.
+    var currentType = _socket?.remoteAddress.type;
+    var currentIp = await myIP();
+    if (currentIp != null) {
+      if (isIPv6Address(currentIp)) {
+        ipv6 = currentIp;
+      } else {
+        ipv4 = currentIp;
+      }
+    }
+
+    // Discover the missing family via an auxiliary connection.
+    Future<String?> discover(InternetAddressType type) async {
+      final accessKey = _accessKey;
+      if (accessKey == null) return null;
+
+      final auxClient =
+          GatekeeperClient(host, port, secure: secure, verbose: verbose);
+      try {
+        var connected = await auxClient.connect(addressType: type);
+        if (!connected) return null;
+
+        var login = await auxClient.login(accessKey);
+        if (!login.ok) return null;
+
+        return await auxClient.myIP();
+      } catch (_) {
+        return null;
+      } finally {
+        auxClient.close();
+      }
+    }
+
+    if (ipv4 == null && currentType != InternetAddressType.IPv4) {
+      try {
+        ipv4 = await discover(InternetAddressType.IPv4);
+      } catch (_) {}
+    }
+
+    if (ipv6 == null && currentType != InternetAddressType.IPv6) {
+      try {
+        ipv6 = await discover(InternetAddressType.IPv6);
+      } catch (_) {}
+    }
+
+    return (ipv4: ipv4, ipv6: ipv6);
   }
 
   /// Processes a command entered by the user.
@@ -449,6 +529,11 @@ class GatekeeperClient {
 
       case 'accept':
         {
+          if (parts.length < 3) {
+            print('** Usage: accept <address|.> <port>');
+            return false;
+          }
+
           var address = parts[1].trim();
           if (address.isEmpty) {
             print('** Empty address');
@@ -461,6 +546,32 @@ class GatekeeperClient {
             return false;
           }
 
+          // `.` means "this client": whitelist both its IPv4 and IPv6 address.
+          if (address == '.') {
+            var ips = await myIPs();
+            var resolved = <String>[
+              if (ips.ipv4 != null) ips.ipv4!,
+              if (ips.ipv6 != null) ips.ipv6!,
+            ];
+
+            if (resolved.isEmpty) {
+              print('** Could not resolve this client\'s IP address(es).');
+              return false;
+            }
+
+            var accepted = <String>[];
+            for (var ip in resolved) {
+              var ok = await acceptAddressOnTCPPort(ip, port);
+              var family = isIPv6Address(ip) ? 'IPv6' : 'IPv4';
+              print('-- Accepted $family `$ip` on port $port: $ok');
+              if (ok) accepted.add(ip);
+            }
+
+            print('-- Accepted IPs on port $port: '
+                '${accepted.isEmpty ? '(none)' : accepted.join(', ')}');
+            return true;
+          }
+
           var accepted = await acceptAddressOnTCPPort(address, port);
           print('-- Accepted address `$address` on port $port: $accepted');
           return true;
@@ -468,6 +579,11 @@ class GatekeeperClient {
 
       case 'unaccept':
         {
+          if (parts.length < 2) {
+            print('** Usage: unaccept <address|.> [port]');
+            return false;
+          }
+
           var address = parts[1].trim();
           if (address.isEmpty) {
             print('** Empty address');
@@ -475,6 +591,27 @@ class GatekeeperClient {
           }
 
           var port = parts.length > 2 ? int.tryParse(parts[2].trim()) : null;
+
+          // `.` means "this client": remove both its IPv4 and IPv6 address.
+          if (address == '.') {
+            var ips = await myIPs();
+            var resolved = <String>[
+              if (ips.ipv4 != null) ips.ipv4!,
+              if (ips.ipv6 != null) ips.ipv6!,
+            ];
+
+            if (resolved.isEmpty) {
+              print('** Could not resolve this client\'s IP address(es).');
+              return false;
+            }
+
+            for (var ip in resolved) {
+              var ok = await unacceptAddressOnTCPPort(ip, port);
+              var family = isIPv6Address(ip) ? 'IPv6' : 'IPv4';
+              print('-- Unaccepted $family `$ip` on port ${port ?? '*'}: $ok');
+            }
+            return true;
+          }
 
           var unaccepted = await unacceptAddressOnTCPPort(address, port);
           print(
@@ -504,6 +641,13 @@ class GatekeeperClient {
           return false;
         }
 
+      case 'help':
+      case '?':
+        {
+          printCommandsHelp();
+          return true;
+        }
+
       case 'exit':
         {
           var ok = await disconnect();
@@ -515,9 +659,29 @@ class GatekeeperClient {
       default:
         {
           print('** Unknown command: `$cmd`');
+          print('   Type `help` or `?` to list the available commands.');
           return false;
         }
     }
+  }
+
+  /// Prints the list of available REPL commands and their usage.
+  static void printCommandsHelp() {
+    print('Available commands:');
+    print('  list | ls | l [ports|accepts|all]  '
+        'List blocked ports and/or accepted addresses (default: all).');
+    print(
+        '  block <port>                       Block a TCP port (IPv4 + IPv6).');
+    print('  unblock <port>                     '
+        'Unblock a TCP port (IPv4 + IPv6).');
+    print('  accept <address|.> <port>          '
+        'Accept an address on a port. `.` = this client (both IPv4 and IPv6).');
+    print('  unaccept <address|.> [port]        '
+        'Remove an accepted address (all ports if omitted). `.` = this client.');
+    print('  myip | my ip                       '
+        'Show this client\'s IP as seen by the server.');
+    print('  help | ?                           Show this help.');
+    print('  exit                               Disconnect and quit.');
   }
 
   /// Closes the connection to the server.

--- a/lib/src/gatekeeper_client.dart
+++ b/lib/src/gatekeeper_client.dart
@@ -313,11 +313,13 @@ class GatekeeperClient {
         .map((e) => e.trim())
         .where((e) => e.isNotEmpty)
         .map((e) {
-          var parts = e.split(':');
-          if (parts.length != 2) return null;
-          var a = parts[0];
-          var p = int.tryParse(parts[1]);
-          if (p == null) return null;
+          // Split on the LAST `:` so IPv6 addresses (which contain `:`) are
+          // parsed correctly; the port is always the trailing segment.
+          var idx = e.lastIndexOf(':');
+          if (idx <= 0 || idx >= e.length - 1) return null;
+          var a = e.substring(0, idx).trim();
+          var p = int.tryParse(e.substring(idx + 1).trim());
+          if (a.isEmpty || p == null) return null;
           return (address: a, port: p);
         })
         .nonNulls

--- a/lib/src/gatekeeper_const.dart
+++ b/lib/src/gatekeeper_const.dart
@@ -1,1 +1,1 @@
-const gatekeeperVersion = '1.0.12';
+const gatekeeperVersion = '1.1.0';

--- a/lib/src/gatekeeper_iptables.dart
+++ b/lib/src/gatekeeper_iptables.dart
@@ -1,9 +1,34 @@
 import 'dart:io';
 
 import 'gatekeeper_base.dart';
+import 'utils.dart';
+
+/// IPv4 firewall binary.
+const String _binIpTables = 'iptables';
+
+/// IPv6 firewall binary.
+const String _binIp6Tables = 'ip6tables';
+
+/// Matches an `ACCEPT` rule line and captures the source address.
+///
+/// Tolerates both `iptables` and `ip6tables -L -n -v` output (the `opt`
+/// column shown by `iptables` as `--` is optional, as some `ip6tables`
+/// versions omit it).
+final RegExp _regExpAcceptAddress =
+    RegExp(r'ACCEPT\s+(?:tcp|6|4)\s+(?:--\s+)?\*\s+\*\s+(\S+)');
+
+/// Matches the destination port (`dpt:<port>`) of a rule line.
+final RegExp _regExpPort = RegExp(r'dpt:(\d\d+)');
 
 /// The [GatekeeperIpTables] class is a concrete implementation of [GatekeeperDriver]
-/// that uses `iptables` or a similar utility to manage TCP ports on a system.
+/// that uses `iptables`/`ip6tables` or a similar utility to manage TCP ports on a system.
+///
+/// IPv4 rules are managed with `iptables` and IPv6 rules with `ip6tables`.
+/// The correct binary is selected from the address family for address-based
+/// operations ([acceptAddressOnTCPPort]/[unacceptAddressOnTCPPort]), while
+/// port-based operations ([blockTCPPort]/[unblockTCPPort]) and listings span
+/// both families. `ip6tables` is optional: when it is not installed, IPv6
+/// operations are skipped gracefully.
 ///
 /// Example usage:
 /// ```dart
@@ -30,6 +55,39 @@ class GatekeeperIpTables extends GatekeeperDriver {
     } catch (e) {
       throw Exception('Failed to resolve binary path: $e');
     }
+  }
+
+  /// Resolves [binaryCommand] like [resolveBinaryPathCached], but returns
+  /// `null` instead of throwing when the binary is not available. Used for the
+  /// optional `ip6tables` binary.
+  Future<String?> _resolveBinaryPathOrNull(String binaryCommand) async {
+    try {
+      var path = await resolveBinaryPathCached(binaryCommand);
+      return path.isNotEmpty ? path : null;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// Returns the firewall binary path for the given [address] family
+  /// (`ip6tables` for IPv6, `iptables` otherwise), or `null` if that binary is
+  /// not available on this system.
+  Future<String?> _resolveBinaryPathForAddress(String address) =>
+      _resolveBinaryPathOrNull(
+          isIPv6Address(address) ? _binIp6Tables : _binIpTables);
+
+  /// Returns the available firewall binary paths: `iptables` (required) plus
+  /// `ip6tables` when installed. Throws if `iptables` is missing.
+  Future<List<String>> _resolveFirewallBinaries() async {
+    final bins = <String>[];
+
+    final ipTables = await resolveBinaryPathCached(_binIpTables);
+    if (ipTables.isNotEmpty) bins.add(ipTables);
+
+    final ip6Tables = await _resolveBinaryPathOrNull(_binIp6Tables);
+    if (ip6Tables != null) bins.add(ip6Tables);
+
+    return bins;
   }
 
   @override
@@ -63,30 +121,29 @@ class GatekeeperIpTables extends GatekeeperDriver {
   @override
   Future<Set<int>> listBlockedTCPPorts(
       {bool sudo = false, Set<int>? allowedPorts}) async {
-    final iptablesBin = await resolveBinaryPathCached('iptables');
-    final iptablesArgs = <String>['-L', 'INPUT', '-n', '-v'];
-
-    var output = await runCommand(
-      iptablesBin,
-      iptablesArgs,
-      sudo: sudo,
-      expectedExitCode: 0,
-    );
-
-    if (output == null || output.isEmpty) return {};
-
-    final regExpPort = RegExp(r'dpt:(\d\d+)');
+    final bins = await _resolveFirewallBinaries();
 
     final blockedPorts = <int>{};
 
-    for (final line in output.split('\n')) {
-      if (line.contains('DROP') || line.contains('REJECT')) {
-        final match = regExpPort.firstMatch(line);
-        if (match != null) {
-          var g1 = match.group(1)!;
-          var p = int.tryParse(g1.trim());
-          if (p != null && p >= 10) {
-            blockedPorts.add(p);
+    for (final bin in bins) {
+      var output = await runCommand(
+        bin,
+        <String>['-L', 'INPUT', '-n', '-v'],
+        sudo: sudo,
+        expectedExitCode: 0,
+      );
+
+      if (output == null || output.isEmpty) continue;
+
+      for (final line in output.split('\n')) {
+        if (line.contains('DROP') || line.contains('REJECT')) {
+          final match = _regExpPort.firstMatch(line);
+          if (match != null) {
+            var g1 = match.group(1)!;
+            var p = int.tryParse(g1.trim());
+            if (p != null && p >= 10) {
+              blockedPorts.add(p);
+            }
           }
         }
       }
@@ -111,26 +168,23 @@ class GatekeeperIpTables extends GatekeeperDriver {
       return false;
     }
 
-    final iptablesBin = await resolveBinaryPathCached('iptables');
-    final iptablesArgs = <String>[
-      '-A',
-      'INPUT',
-      '-p',
-      'tcp',
-      '--dport',
-      '$port',
-      '-j',
-      'DROP',
-    ];
+    // Block on every available family so the port is actually closed for both
+    // IPv4 and IPv6 traffic.
+    final bins = await _resolveFirewallBinaries();
 
-    var output = await runCommand(
-      iptablesBin,
-      iptablesArgs,
-      sudo: sudo,
-      expectedExitCode: 0,
-    );
+    var allOk = true;
+    for (final bin in bins) {
+      var output = await runCommand(
+        bin,
+        <String>['-A', 'INPUT', '-p', 'tcp', '--dport', '$port', '-j', 'DROP'],
+        sudo: sudo,
+        expectedExitCode: 0,
+      );
 
-    if (output == null) {
+      if (output == null) allOk = false;
+    }
+
+    if (!allOk) {
       return false;
     }
 
@@ -151,26 +205,21 @@ class GatekeeperIpTables extends GatekeeperDriver {
       return false;
     }
 
-    final iptablesBin = await resolveBinaryPathCached('iptables');
-    final iptablesArgs = <String>[
-      '-D',
-      'INPUT',
-      '-p',
-      'tcp',
-      '--dport',
-      '$port',
-      '-j',
-      'DROP',
-    ];
+    final bins = await _resolveFirewallBinaries();
 
-    var output = await runCommand(
-      iptablesBin,
-      iptablesArgs,
-      sudo: sudo,
-      expectedExitCode: 0,
-    );
+    var allOk = true;
+    for (final bin in bins) {
+      var output = await runCommand(
+        bin,
+        <String>['-D', 'INPUT', '-p', 'tcp', '--dport', '$port', '-j', 'DROP'],
+        sudo: sudo,
+        expectedExitCode: 0,
+      );
 
-    if (output == null) {
+      if (output == null) allOk = false;
+    }
+
+    if (!allOk) {
       return false;
     }
 
@@ -182,34 +231,31 @@ class GatekeeperIpTables extends GatekeeperDriver {
   @override
   Future<Set<(String, int)>> listAcceptedAddressesOnTCPPorts(
       {bool sudo = false, Set<int>? allowedPorts}) async {
-    final iptablesBin = await resolveBinaryPathCached('iptables');
-    final iptablesArgs = <String>['-L', 'INPUT', '-n', '-v'];
-
-    var output = await runCommand(
-      iptablesBin,
-      iptablesArgs,
-      sudo: sudo,
-      expectedExitCode: 0,
-    );
-
-    if (output == null || output.isEmpty) return {};
-
-    final regExpAddress =
-        RegExp(r'ACCEPT\s+(?:tcp|6|4)\s+--\s+\*\s+\*\s+(\S+)');
-    final regExpPort = RegExp(r'dpt:(\d\d+)');
+    final bins = await _resolveFirewallBinaries();
 
     final accepts = <(String, int)>{};
 
-    for (final line in output.split('\n')) {
-      if (line.contains('ACCEPT')) {
-        final matchAddress = regExpAddress.firstMatch(line);
-        final matchPort = regExpPort.firstMatch(line);
-        if (matchAddress != null && matchPort != null) {
-          var address = matchAddress.group(1)!;
-          var gPort = matchPort.group(1)!;
-          var port = int.tryParse(gPort.trim());
-          if (address.isNotEmpty && port != null && port >= 10) {
-            accepts.add((address, port));
+    for (final bin in bins) {
+      var output = await runCommand(
+        bin,
+        <String>['-L', 'INPUT', '-n', '-v'],
+        sudo: sudo,
+        expectedExitCode: 0,
+      );
+
+      if (output == null || output.isEmpty) continue;
+
+      for (final line in output.split('\n')) {
+        if (line.contains('ACCEPT')) {
+          final matchAddress = _regExpAcceptAddress.firstMatch(line);
+          final matchPort = _regExpPort.firstMatch(line);
+          if (matchAddress != null && matchPort != null) {
+            var address = normalizeIpAddress(matchAddress.group(1)!);
+            var gPort = matchPort.group(1)!;
+            var port = int.tryParse(gPort.trim());
+            if (address.isNotEmpty && port != null && port >= 10) {
+              accepts.add((address, port));
+            }
           }
         }
       }
@@ -235,23 +281,27 @@ class GatekeeperIpTables extends GatekeeperDriver {
       return false;
     }
 
-    final iptablesBin = await resolveBinaryPathCached('iptables');
-    final iptablesArgs = <String>[
-      '-I',
-      'INPUT',
-      '-p',
-      'tcp',
-      '--dport',
-      '$port',
-      '-s',
-      address,
-      '-j',
-      'ACCEPT',
-    ];
+    // Select `iptables` or `ip6tables` from the address family.
+    final bin = await _resolveBinaryPathForAddress(address);
+    if (bin == null) {
+      // IPv6 address requested but `ip6tables` is not available.
+      return false;
+    }
 
     var output = await runCommand(
-      iptablesBin,
-      iptablesArgs,
+      bin,
+      <String>[
+        '-I',
+        'INPUT',
+        '-p',
+        'tcp',
+        '--dport',
+        '$port',
+        '-s',
+        address,
+        '-j',
+        'ACCEPT',
+      ],
       sudo: sudo,
       expectedExitCode: 0,
     );
@@ -273,30 +323,33 @@ class GatekeeperIpTables extends GatekeeperDriver {
       required bool allowAllPorts}) async {
     address = _checkAddress(address);
 
-    final iptablesBin = await resolveBinaryPathCached('iptables');
-    final iptablesArgs = <String>['-L', 'INPUT', '-n', '-v', '--line-numbers'];
+    // The address family determines which firewall table holds the rule.
+    final bin = await _resolveBinaryPathForAddress(address);
+    if (bin == null) {
+      return false;
+    }
 
     var output = await runCommand(
-      iptablesBin,
-      iptablesArgs,
+      bin,
+      <String>['-L', 'INPUT', '-n', '-v', '--line-numbers'],
       sudo: sudo,
       expectedExitCode: 0,
     );
 
     if (output == null || output.isEmpty) return false;
 
-    final regExpAddress =
-        RegExp(r'ACCEPT\s+(?:tcp|6|4)\s+--\s+\*\s+\*\s+(\S+)');
-    final regExpPort = RegExp(r'dpt:(\d\d+)');
-
     var anyCmdOK = false;
 
-    for (final line in output.split('\n')) {
+    // Iterate in reverse so deleting a rule by line number does not shift the
+    // numbers of rules still pending deletion.
+    final lines = output.split('\n').reversed;
+
+    for (final line in lines) {
       if (line.contains('ACCEPT')) {
-        final matchAddress = regExpAddress.firstMatch(line);
-        final matchPort = regExpPort.firstMatch(line);
+        final matchAddress = _regExpAcceptAddress.firstMatch(line);
+        final matchPort = _regExpPort.firstMatch(line);
         if (matchAddress != null && matchPort != null) {
-          var a = matchAddress.group(1)!;
+          var a = normalizeIpAddress(matchAddress.group(1)!);
           var g1 = matchPort.group(1)!;
           var p = int.tryParse(g1.trim());
 
@@ -308,7 +361,7 @@ class GatekeeperIpTables extends GatekeeperDriver {
               final iptablesDelArgs = <String>['-D', 'INPUT', '$n'];
 
               var output = await runCommand(
-                iptablesBin,
+                bin,
                 iptablesDelArgs,
                 sudo: sudo,
                 expectedExitCode: 0,
@@ -342,7 +395,7 @@ class GatekeeperIpTables extends GatekeeperDriver {
 
   @override
   Future<bool> resolve() async {
-    final iptablesBin = await resolveBinaryPathCached('iptables');
+    final iptablesBin = await resolveBinaryPathCached(_binIpTables);
     return iptablesBin.isNotEmpty;
   }
 
@@ -368,7 +421,9 @@ String _checkAddress(String address) {
 
 String? _normalizeAddress(String? address) {
   if (address == null) return null;
-  address = address.trim();
+  // Collapse IPv4-mapped IPv6 (`::ffff:1.2.3.4`) to plain IPv4 so it targets
+  // the IPv4 table.
+  address = normalizeIpAddress(address);
   if (address.isEmpty) return null;
 
   // If has any invalid character:

--- a/lib/src/gatekeeper_server.dart
+++ b/lib/src/gatekeeper_server.dart
@@ -34,7 +34,8 @@ class GatekeeperServer {
   /// The port the server listens on for incoming connections.
   final int listenPort;
 
-  /// The address the server binds to. Defaults to [InternetAddress.anyIPv4] if not specified.
+  /// The address the server binds to. Defaults to [InternetAddress.anyIPv6]
+  /// (dual-stack, see [_startImpl]) if not specified.
   final Object address;
 
   /// The maximum number of consecutive login errors allowed before
@@ -52,7 +53,7 @@ class GatekeeperServer {
   /// - [gatekeeper]: the [Gatekeeper] instance.
   /// - [accessKey]: the access key for login.
   /// - [listenPort]: the port to listen for connections. NO default port for security purpose.
-  /// - [address]: Optional addresses to bind. See [ServerSocket.bind]. Default: [InternetAddress.anyIPv4]
+  /// - [address]: Optional addresses to bind. See [ServerSocket.bind]. Default: [InternetAddress.anyIPv6] (dual-stack: accepts both IPv4 and IPv6 connections)
   /// - [loginErrorLimit]: The limit of login errors to block a [Socket]. Default: 3 ; Minimal: 3
   /// - [blockingTime]: The [Socket] blocking time. Default: 10min
   GatekeeperServer(this.gatekeeper,
@@ -62,7 +63,7 @@ class GatekeeperServer {
       int? loginErrorLimit,
       Duration? blockingTime,
       this.verbose = false})
-      : address = address ?? InternetAddress.anyIPv4,
+      : address = address ?? InternetAddress.anyIPv6,
         loginErrorLimit = normalizeLoginErrorLimit(loginErrorLimit),
         blockingTime = normalizeBlockingTime(blockingTime) {
     if (accessKey.length < 32) {
@@ -125,7 +126,11 @@ class GatekeeperServer {
   }
 
   Future<bool> _startImpl() async {
-    var server = _server = await ServerSocket.bind(address, listenPort);
+    // `v6Only: false` makes an IPv6 bind dual-stack, so a single socket
+    // accepts both IPv6 and IPv4 (the latter as IPv4-mapped) connections.
+    // It is ignored when binding an IPv4 address.
+    var server =
+        _server = await ServerSocket.bind(address, listenPort, v6Only: false);
     server.listen(_onAcceptSocket);
     return true;
   }
@@ -214,7 +219,9 @@ class _SocketHandler {
   StreamSubscription<Uint8List>? _socketSubscription;
 
   _SocketHandler(this.socket, this.server) {
-    remoteAddress = socket.remoteAddress.address;
+    // Normalize IPv4-mapped IPv6 (`::ffff:1.2.3.4`) to plain IPv4 so the
+    // address handed to the firewall driver targets the correct family.
+    remoteAddress = normalizeIpAddress(socket.remoteAddress.address);
 
     if (server._isSocketAddressBlocked(this)) {
       close();

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -1,5 +1,37 @@
 import 'dart:typed_data';
 
+/// Normalizes an IP [address] string so all layers agree on its family.
+///
+/// - Trims surrounding whitespace.
+/// - Converts an IPv4-mapped IPv6 address (`::ffff:1.2.3.4`) to its plain
+///   IPv4 form (`1.2.3.4`), since the kernel filters such traffic through the
+///   IPv4 stack (`iptables`), not `ip6tables`.
+///
+/// Any other value (plain IPv4 or IPv6) is returned trimmed and unchanged.
+String normalizeIpAddress(String address) {
+  address = address.trim();
+
+  // IPv4-mapped IPv6: `::ffff:1.2.3.4` (the IPv4 part is in dotted-quad form).
+  var match = RegExp(r'^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$',
+          caseSensitive: false)
+      .firstMatch(address);
+  if (match != null) {
+    return match.group(1)!;
+  }
+
+  return address;
+}
+
+/// Returns `true` if [address] is an IPv6 address.
+///
+/// Expects an already [normalizeIpAddress]-normalized value, so IPv4-mapped
+/// addresses (handled there) are treated as IPv4.
+bool isIPv6Address(String address) {
+  address = address.trim();
+  // IPv4 addresses never contain `:`; IPv6 always does.
+  return address.contains(':');
+}
+
 extension Uint8ListExtension on Uint8List {
   Uint8List merge(Uint8List other) {
     if (isEmpty) return other;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: gatekeeper
 description: Gatekeeper is a Dart package for managing TCP ports with a manager, server, and client. Control ports programmatically, via IPC, or remotely for efficient port management.
-version: 1.0.12
+version: 1.1.0
 repository: https://github.com/gmpassos/gatekeeper
 
 environment:

--- a/test/config_probe.dart
+++ b/test/config_probe.dart
@@ -1,0 +1,18 @@
+import 'dart:convert';
+
+import 'package:gatekeeper/gatekeeper_client.dart';
+
+/// Helper invoked as a subprocess (with a custom `HOME`/`USERPROFILE`) by
+/// `gatekeeper_config_test.dart` to exercise [GatekeeperClientConfig.load],
+/// which reads the `.gatekeeper` directory from the user's home.
+///
+/// Prints the loaded configuration as a single JSON line on stdout.
+void main() {
+  final c = GatekeeperClientConfig.load();
+  print(jsonEncode({
+    'host': c.host,
+    'port': c.port,
+    'accessKey': c.accessKey,
+    'verbose': c.verbose,
+  }));
+}

--- a/test/gatekeeper_client_commands_test.dart
+++ b/test/gatekeeper_client_commands_test.dart
@@ -12,8 +12,7 @@ void main() {
 
     setUp(() async {
       server = GatekeeperServer(
-        Gatekeeper(
-            driver: GatekeeperMock(), allowedPorts: {2223, 2224}),
+        Gatekeeper(driver: GatekeeperMock(), allowedPorts: {2223, 2224}),
         listenPort: listenPort,
         accessKey: accessKey,
       );

--- a/test/gatekeeper_client_commands_test.dart
+++ b/test/gatekeeper_client_commands_test.dart
@@ -1,0 +1,98 @@
+import 'package:gatekeeper/gatekeeper_client.dart';
+import 'package:gatekeeper/gatekeeper_server.dart';
+import 'package:test/test.dart';
+
+const accessKey = '0123456789abcdefghijklmnopqrstuvwxyz';
+
+void main() {
+  group('GatekeeperClient.processCommand', () {
+    late GatekeeperServer server;
+    late GatekeeperClient client;
+    const listenPort = 2246;
+
+    setUp(() async {
+      server = GatekeeperServer(
+        Gatekeeper(
+            driver: GatekeeperMock(), allowedPorts: {2223, 2224}),
+        listenPort: listenPort,
+        accessKey: accessKey,
+      );
+      expect(await server.start(), isTrue);
+
+      client = GatekeeperClient('localhost', listenPort, secure: true);
+      expect(await client.connect(), isTrue);
+      expect((await client.login(accessKey)).ok, isTrue);
+    });
+
+    tearDown(() {
+      client.close();
+      server.close();
+    });
+
+    test('block / unblock commands', () async {
+      expect(await client.processCommand('block 2223'), isTrue);
+      expect(await client.listBlockedTCPPorts(), equals({2223}));
+
+      expect(await client.processCommand('unblock 2223'), isTrue);
+      expect(await client.listBlockedTCPPorts(), equals(<int>{}));
+
+      // Invalid ports are rejected client-side.
+      expect(await client.processCommand('block abc'), isFalse);
+      expect(await client.processCommand('block 5'), isFalse);
+      expect(await client.processCommand('unblock abc'), isFalse);
+    });
+
+    test('accept / unaccept literal address', () async {
+      expect(await client.processCommand('accept 1.2.3.4 2223'), isTrue);
+      expect(
+          await client.listAcceptedAddressesOnTCPPorts(),
+          equals(<({String address, int port})>{
+            (address: '1.2.3.4', port: 2223),
+          }));
+
+      expect(await client.processCommand('unaccept 1.2.3.4 2223'), isTrue);
+      expect(await client.listAcceptedAddressesOnTCPPorts(),
+          equals(<({String address, int port})>{}));
+    });
+
+    test('accept invalid arguments', () async {
+      expect(await client.processCommand('accept 1.2.3.4'), isFalse); // no port
+      expect(await client.processCommand('accept 1.2.3.4 5'), isFalse); // <10
+      expect(await client.processCommand('unaccept'), isFalse); // no address
+    });
+
+    test('list variants', () async {
+      await client.processCommand('block 2223');
+      await client.processCommand('accept 1.2.3.4 2224');
+
+      expect(await client.processCommand('list ports'), isTrue);
+      expect(await client.processCommand('l blocked'), isTrue);
+      expect(await client.processCommand('ls accepts'), isTrue);
+      expect(await client.processCommand('list addresses'), isTrue);
+      expect(await client.processCommand('list all'), isTrue);
+      expect(await client.processCommand('list'), isTrue); // default: all
+      expect(await client.processCommand('list bogus'), isFalse);
+    });
+
+    test('myip / my ip', () async {
+      expect(await client.processCommand('myip'), isTrue);
+      expect(await client.processCommand('my ip'), isTrue);
+      expect(await client.processCommand('my something'), isFalse);
+
+      var ip = await client.myIP();
+      expect(ip, anyOf(equals('127.0.0.1'), equals('::1')));
+    });
+
+    test('help / ? / unknown', () async {
+      expect(await client.processCommand('help'), isTrue);
+      expect(await client.processCommand('?'), isTrue);
+      expect(await client.processCommand('bogus-cmd'), isFalse);
+      expect(await client.processCommand(''), isFalse);
+      expect(await client.processCommand(null), isFalse);
+    });
+
+    test('disconnect', () async {
+      expect(await client.disconnect(), isTrue);
+    });
+  });
+}

--- a/test/gatekeeper_client_dualstack_test.dart
+++ b/test/gatekeeper_client_dualstack_test.dart
@@ -1,0 +1,68 @@
+import 'package:gatekeeper/gatekeeper_client.dart';
+import 'package:gatekeeper/gatekeeper_server.dart';
+import 'package:test/test.dart';
+
+const accessKey = '0123456789abcdefghijklmnopqrstuvwxyz';
+
+void main() {
+  group('GatekeeperClient dual-stack', () {
+    test('myIP / myIPs / accept . / unaccept . (secure)',
+        () => _testDualStack(secure: true),
+        timeout: Timeout(Duration(minutes: 1)));
+
+    test('myIP / myIPs / accept . / unaccept . (insecure)',
+        () => _testDualStack(secure: false),
+        timeout: Timeout(Duration(minutes: 1)));
+  });
+}
+
+Future<void> _testDualStack({required bool secure}) async {
+  final listenPort = 2245;
+
+  final driver = GatekeeperMock();
+
+  final server = GatekeeperServer(
+    Gatekeeper(driver: driver, allowAllPorts: true),
+    listenPort: listenPort,
+    accessKey: accessKey,
+  );
+
+  expect(await server.start(), isTrue);
+
+  try {
+    final client = GatekeeperClient('localhost', listenPort, secure: secure);
+
+    expect(await client.connect(), isTrue);
+    expect((await client.login(accessKey)).ok, isTrue);
+
+    // `myip`: the current connection's server-visible loopback address.
+    var ip = await client.myIP();
+    expect(ip, anyOf(equals('127.0.0.1'), equals('::1')));
+
+    // `myIPs`: should discover BOTH families via an auxiliary connection.
+    var ips = await client.myIPs();
+    expect(ips.ipv4, equals('127.0.0.1'));
+    expect(ips.ipv6, equals('::1'));
+
+    // `accept . <port>`: whitelists both families.
+    expect(await client.processCommand('accept . 2223'), isTrue);
+
+    expect(
+        await client.listAcceptedAddressesOnTCPPorts(),
+        equals(<({String address, int port})>{
+          (address: '127.0.0.1', port: 2223),
+          (address: '::1', port: 2223),
+        }));
+
+    // `unaccept . <port>`: removes both families.
+    expect(await client.processCommand('unaccept . 2223'), isTrue);
+
+    expect(await client.listAcceptedAddressesOnTCPPorts(),
+        equals(<({String address, int port})>{}));
+
+    client.close();
+    expect(client.isConnected, isFalse);
+  } finally {
+    server.close();
+  }
+}

--- a/test/gatekeeper_config_test.dart
+++ b/test/gatekeeper_config_test.dart
@@ -73,9 +73,9 @@ void main() {
       final home = Directory.systemTemp.createTempSync('gk_json');
       try {
         Directory('${home.path}/.gatekeeper').createSync();
-        File('${home.path}/.gatekeeper/config.json').writeAsStringSync(
-            '{"host":"example.com","port":2243,'
-            '"access-key":"the-key","verbose":true}');
+        File('${home.path}/.gatekeeper/config.json')
+            .writeAsStringSync('{"host":"example.com","port":2243,'
+                '"access-key":"the-key","verbose":true}');
 
         final cfg = await loadWithHome(home);
         expect(cfg['host'], equals('example.com'));

--- a/test/gatekeeper_config_test.dart
+++ b/test/gatekeeper_config_test.dart
@@ -1,0 +1,124 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:gatekeeper/gatekeeper_client.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('GatekeeperClientConfig (pure)', () {
+    test('constructor defaults', () {
+      const c = GatekeeperClientConfig();
+      expect(c.host, isNull);
+      expect(c.port, isNull);
+      expect(c.accessKey, isNull);
+      expect(c.verbose, isFalse);
+    });
+
+    test('resolveUserHome matches HOME on POSIX', () {
+      if (Platform.isWindows) return;
+      expect(GatekeeperClientConfig.resolveUserHome(),
+          equals(Platform.environment['HOME']));
+    });
+
+    test('resolveDirectory points at the `.gatekeeper` dir', () {
+      final dir = GatekeeperClientConfig.resolveDirectory();
+      // Null only if the home dir can't be resolved (not the case in CI).
+      if (dir != null) {
+        expect(dir.path, endsWith('.gatekeeper'));
+      }
+    });
+
+    test('load does not throw', () {
+      expect(() => GatekeeperClientConfig.load(), returnsNormally);
+    });
+  });
+
+  group('GatekeeperClientConfig.load (subprocess with custom HOME)', () {
+    Future<Map<String, dynamic>> loadWithHome(Directory home) async {
+      final env = Map<String, String>.from(Platform.environment);
+      env['HOME'] = home.path;
+      env['USERPROFILE'] = home.path; // Windows fallback.
+
+      final result = await Process.run(
+        Platform.resolvedExecutable,
+        ['run', 'test/config_probe.dart'],
+        environment: env,
+      );
+
+      expect(result.exitCode, equals(0),
+          reason: 'stderr: ${result.stderr}\nstdout: ${result.stdout}');
+
+      final lines = (result.stdout as String)
+          .trim()
+          .split('\n')
+          .where((l) => l.startsWith('{'))
+          .toList();
+      return jsonDecode(lines.last) as Map<String, dynamic>;
+    }
+
+    test('empty home -> empty config', () async {
+      final home = Directory.systemTemp.createTempSync('gk_empty');
+      try {
+        final cfg = await loadWithHome(home);
+        expect(cfg['host'], isNull);
+        expect(cfg['port'], isNull);
+        expect(cfg['accessKey'], isNull);
+        expect(cfg['verbose'], isFalse);
+      } finally {
+        home.deleteSync(recursive: true);
+      }
+    });
+
+    test('config.json is parsed', () async {
+      final home = Directory.systemTemp.createTempSync('gk_json');
+      try {
+        Directory('${home.path}/.gatekeeper').createSync();
+        File('${home.path}/.gatekeeper/config.json').writeAsStringSync(
+            '{"host":"example.com","port":2243,'
+            '"access-key":"the-key","verbose":true}');
+
+        final cfg = await loadWithHome(home);
+        expect(cfg['host'], equals('example.com'));
+        expect(cfg['port'], equals(2243));
+        expect(cfg['accessKey'], equals('the-key'));
+        expect(cfg['verbose'], isTrue);
+      } finally {
+        home.deleteSync(recursive: true);
+      }
+    });
+
+    test('access-key file used when config.json omits it', () async {
+      final home = Directory.systemTemp.createTempSync('gk_keyfile');
+      try {
+        Directory('${home.path}/.gatekeeper').createSync();
+        File('${home.path}/.gatekeeper/config.json')
+            .writeAsStringSync('{"host":"h","port":10}');
+        File('${home.path}/.gatekeeper/access-key')
+            .writeAsStringSync('  key-from-file  \n');
+
+        final cfg = await loadWithHome(home);
+        expect(cfg['host'], equals('h'));
+        expect(cfg['port'], equals(10));
+        expect(cfg['accessKey'], equals('key-from-file'));
+      } finally {
+        home.deleteSync(recursive: true);
+      }
+    });
+
+    test('invalid config.json is tolerated', () async {
+      final home = Directory.systemTemp.createTempSync('gk_bad');
+      try {
+        Directory('${home.path}/.gatekeeper').createSync();
+        File('${home.path}/.gatekeeper/config.json')
+            .writeAsStringSync('{ not valid json ');
+
+        final cfg = await loadWithHome(home);
+        // Falls back to an empty config rather than throwing.
+        expect(cfg['host'], isNull);
+        expect(cfg['port'], isNull);
+      } finally {
+        home.deleteSync(recursive: true);
+      }
+    });
+  });
+}

--- a/test/gatekeeper_iptables_fake_test.dart
+++ b/test/gatekeeper_iptables_fake_test.dart
@@ -77,8 +77,8 @@ class _FakeIpTables extends GatekeeperIpTables {
       rules.insert(0, _Rule(target, portN, source));
       return '';
     } else if (op == '-D') {
-      final idx = rules.indexWhere((r) =>
-          r.target == target && r.port == portN && r.source == source);
+      final idx = rules.indexWhere(
+          (r) => r.target == target && r.port == portN && r.source == source);
       if (idx >= 0) {
         rules.removeAt(idx);
         return '';
@@ -119,12 +119,10 @@ void main() {
     test('block / list / unblock spans both families', () async {
       final fw = _FakeIpTables();
 
-      expect(
-          await fw.listBlockedTCPPorts(allowedPorts: null), equals(<int>{}));
+      expect(await fw.listBlockedTCPPorts(allowedPorts: null), equals(<int>{}));
 
       expect(
-          await fw.blockTCPPort(2223,
-              allowedPorts: null, allowAllPorts: true),
+          await fw.blockTCPPort(2223, allowedPorts: null, allowAllPorts: true),
           isTrue);
       expect(await fw.listBlockedTCPPorts(allowedPorts: null), equals({2223}));
 
@@ -136,8 +134,7 @@ void main() {
           await fw.unblockTCPPort(2223,
               allowedPorts: null, allowAllPorts: true),
           isTrue);
-      expect(
-          await fw.listBlockedTCPPorts(allowedPorts: null), equals(<int>{}));
+      expect(await fw.listBlockedTCPPorts(allowedPorts: null), equals(<int>{}));
     });
 
     test('accept IPv4 uses iptables, IPv6 uses ip6tables', () async {
@@ -190,8 +187,7 @@ void main() {
           await fw.unacceptAddressOnTCPPort('2001:db8::1', 2223,
               allowedPorts: null, allowAllPorts: true),
           isTrue);
-      expect(
-          await fw.listAcceptedAddressesOnTCPPorts(allowedPorts: null),
+      expect(await fw.listAcceptedAddressesOnTCPPorts(allowedPorts: null),
           equals(<(String, int)>{('2001:db8::1', 2224)}));
 
       // Remove from all ports (port == null).

--- a/test/gatekeeper_iptables_fake_test.dart
+++ b/test/gatekeeper_iptables_fake_test.dart
@@ -1,0 +1,239 @@
+import 'package:gatekeeper/gatekeeper_iptables.dart';
+import 'package:test/test.dart';
+
+/// A single emulated firewall rule.
+class _Rule {
+  final String target; // DROP | ACCEPT
+  final int port;
+  final String source; // `0.0.0.0/0` for DROP, an address for ACCEPT
+
+  _Rule(this.target, this.port, this.source);
+}
+
+/// A [GatekeeperIpTables] whose binary resolution and command execution are
+/// emulated in-memory, so the real `-L` output parsing and rule-management
+/// logic of the driver can be exercised without `iptables`/`ip6tables`
+/// installed.
+class _FakeIpTables extends GatekeeperIpTables {
+  final bool hasIp6tables;
+
+  /// Emulated rule tables keyed by binary name (`iptables` / `ip6tables`).
+  final Map<String, List<_Rule>> _tables = {
+    'iptables': [],
+    'ip6tables': [],
+  };
+
+  final List<String> runLog = [];
+
+  _FakeIpTables({this.hasIp6tables = true});
+
+  String _binName(String binaryPath) =>
+      binaryPath.split('/').last; // `/sbin/iptables` -> `iptables`
+
+  @override
+  Future<String> resolveBinaryPath(String binaryCommand) async {
+    if (binaryCommand == 'ip6tables' && !hasIp6tables) {
+      throw Exception('Command not found: ip6tables');
+    }
+    return '/sbin/$binaryCommand';
+  }
+
+  @override
+  Future<String?> runCommand(String binaryPath, List<String> args,
+      {bool sudo = false, int? expectedExitCode}) async {
+    runLog.add('$binaryPath ${args.join(' ')}');
+
+    final rules = _tables[_binName(binaryPath)]!;
+
+    // Listing: `-L INPUT -n -v [--line-numbers]`
+    if (args.isNotEmpty && args[0] == '-L') {
+      final withLineNumbers = args.contains('--line-numbers');
+      return _renderListing(rules, withLineNumbers: withLineNumbers);
+    }
+
+    // Delete by line number: `-D INPUT <n>`
+    if (args.length == 3 && args[0] == '-D' && args[1] == 'INPUT') {
+      final n = int.tryParse(args[2]);
+      if (n != null && n >= 1 && n <= rules.length) {
+        rules.removeAt(n - 1);
+        return '';
+      }
+      return null;
+    }
+
+    // Rule mutation: `-A|-I|-D INPUT -p tcp --dport <port> [-s <addr>] -j <T>`
+    final op = args[0];
+    final port = _argValue(args, '--dport');
+    final target = _argValue(args, '-j');
+    final source = _argValue(args, '-s') ?? '0.0.0.0/0';
+
+    if (port == null || target == null) return null;
+    final portN = int.parse(port);
+
+    if (op == '-A') {
+      rules.add(_Rule(target, portN, source));
+      return '';
+    } else if (op == '-I') {
+      rules.insert(0, _Rule(target, portN, source));
+      return '';
+    } else if (op == '-D') {
+      final idx = rules.indexWhere((r) =>
+          r.target == target && r.port == portN && r.source == source);
+      if (idx >= 0) {
+        rules.removeAt(idx);
+        return '';
+      }
+      return null;
+    }
+
+    return null;
+  }
+
+  String? _argValue(List<String> args, String flag) {
+    final i = args.indexOf(flag);
+    if (i < 0 || i + 1 >= args.length) return null;
+    return args[i + 1];
+  }
+
+  String _renderListing(List<_Rule> rules, {required bool withLineNumbers}) {
+    final buf = StringBuffer();
+    buf.writeln('Chain INPUT (policy ACCEPT 0 packets, 0 bytes)');
+    buf.writeln('${withLineNumbers ? 'num  ' : ''}'
+        ' pkts bytes target     prot opt in     out     source               destination');
+    for (var i = 0; i < rules.length; i++) {
+      final r = rules[i];
+      final prefix = withLineNumbers ? '${i + 1}    ' : '';
+      buf.writeln('$prefix    0     0 ${r.target.padRight(10)} tcp  --  '
+          '*      *       ${r.source.padRight(20)} 0.0.0.0/0            tcp dpt:${r.port}');
+    }
+    return buf.toString();
+  }
+}
+
+void main() {
+  group('GatekeeperIpTables (emulated firewall)', () {
+    test('resolve requires iptables', () async {
+      expect(await _FakeIpTables().resolve(), isTrue);
+    });
+
+    test('block / list / unblock spans both families', () async {
+      final fw = _FakeIpTables();
+
+      expect(
+          await fw.listBlockedTCPPorts(allowedPorts: null), equals(<int>{}));
+
+      expect(
+          await fw.blockTCPPort(2223,
+              allowedPorts: null, allowAllPorts: true),
+          isTrue);
+      expect(await fw.listBlockedTCPPorts(allowedPorts: null), equals({2223}));
+
+      // Applied to BOTH iptables and ip6tables.
+      expect(fw._tables['iptables']!.any((r) => r.port == 2223), isTrue);
+      expect(fw._tables['ip6tables']!.any((r) => r.port == 2223), isTrue);
+
+      expect(
+          await fw.unblockTCPPort(2223,
+              allowedPorts: null, allowAllPorts: true),
+          isTrue);
+      expect(
+          await fw.listBlockedTCPPorts(allowedPorts: null), equals(<int>{}));
+    });
+
+    test('accept IPv4 uses iptables, IPv6 uses ip6tables', () async {
+      final fw = _FakeIpTables();
+
+      expect(
+          await fw.acceptAddressOnTCPPort('1.2.3.4', 2223,
+              allowedPorts: null, allowAllPorts: true),
+          isTrue);
+      expect(
+          await fw.acceptAddressOnTCPPort('2001:db8::1', 2223,
+              allowedPorts: null, allowAllPorts: true),
+          isTrue);
+
+      // Routed to the correct table by family.
+      expect(fw._tables['iptables']!.map((r) => r.source), contains('1.2.3.4'));
+      expect(fw._tables['ip6tables']!.map((r) => r.source),
+          contains('2001:db8::1'));
+
+      expect(
+          await fw.listAcceptedAddressesOnTCPPorts(allowedPorts: null),
+          equals(<(String, int)>{
+            ('1.2.3.4', 2223),
+            ('2001:db8::1', 2223),
+          }));
+    });
+
+    test('IPv4-mapped IPv6 is accepted as IPv4', () async {
+      final fw = _FakeIpTables();
+
+      expect(
+          await fw.acceptAddressOnTCPPort('::ffff:1.2.3.4', 2223,
+              allowedPorts: null, allowAllPorts: true),
+          isTrue);
+
+      expect(fw._tables['iptables']!.map((r) => r.source), contains('1.2.3.4'));
+      expect(fw._tables['ip6tables'], isEmpty);
+    });
+
+    test('unaccept removes the rule from its family table', () async {
+      final fw = _FakeIpTables();
+
+      await fw.acceptAddressOnTCPPort('2001:db8::1', 2223,
+          allowedPorts: null, allowAllPorts: true);
+      await fw.acceptAddressOnTCPPort('2001:db8::1', 2224,
+          allowedPorts: null, allowAllPorts: true);
+
+      // Remove a single port.
+      expect(
+          await fw.unacceptAddressOnTCPPort('2001:db8::1', 2223,
+              allowedPorts: null, allowAllPorts: true),
+          isTrue);
+      expect(
+          await fw.listAcceptedAddressesOnTCPPorts(allowedPorts: null),
+          equals(<(String, int)>{('2001:db8::1', 2224)}));
+
+      // Remove from all ports (port == null).
+      await fw.acceptAddressOnTCPPort('2001:db8::1', 2225,
+          allowedPorts: null, allowAllPorts: true);
+      expect(
+          await fw.unacceptAddressOnTCPPort('2001:db8::1', null,
+              allowedPorts: null, allowAllPorts: true),
+          isTrue);
+      expect(await fw.listAcceptedAddressesOnTCPPorts(allowedPorts: null),
+          equals(<(String, int)>{}));
+    });
+
+    test('IPv6 accept returns false when ip6tables is unavailable', () async {
+      final fw = _FakeIpTables(hasIp6tables: false);
+
+      expect(
+          await fw.acceptAddressOnTCPPort('2001:db8::1', 2223,
+              allowedPorts: null, allowAllPorts: true),
+          isFalse);
+
+      // IPv4 still works.
+      expect(
+          await fw.acceptAddressOnTCPPort('1.2.3.4', 2223,
+              allowedPorts: null, allowAllPorts: true),
+          isTrue);
+    });
+
+    test('allowedPorts is enforced', () async {
+      final fw = _FakeIpTables();
+
+      expect(
+          await fw.blockTCPPort(2223,
+              allowedPorts: {2224}, allowAllPorts: false),
+          isFalse);
+
+      expect(
+          await fw.acceptAddressOnTCPPort('1.2.3.4', 2223,
+              allowedPorts: {2224}, allowAllPorts: false),
+          isFalse);
+
+      expect(await fw.listBlockedTCPPorts(allowedPorts: null), equals(<int>{}));
+    });
+  });
+}

--- a/test/gatekeeper_iptables_test.dart
+++ b/test/gatekeeper_iptables_test.dart
@@ -1,0 +1,69 @@
+import 'package:gatekeeper/gatekeeper_iptables.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('GatekeeperIpTables validation', () {
+    // These exercise the argument validation that runs *before* any
+    // `iptables`/`ip6tables` binary is resolved, so they do not require the
+    // firewall tools to be installed.
+    final driver = GatekeeperIpTables();
+
+    test('acceptAddressOnTCPPort: invalid port throws', () {
+      expect(
+        () => driver.acceptAddressOnTCPPort('1.2.3.4', 5,
+            allowedPorts: null, allowAllPorts: true),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('acceptAddressOnTCPPort: invalid address throws', () {
+      expect(
+        () => driver.acceptAddressOnTCPPort('not an ip!', 22,
+            allowedPorts: null, allowAllPorts: true),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('acceptAddressOnTCPPort: address with ".." throws', () {
+      expect(
+        () => driver.acceptAddressOnTCPPort('1.2..3.4', 22,
+            allowedPorts: null, allowAllPorts: true),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('acceptAddressOnTCPPort: IPv6 address passes validation', () async {
+      // Valid IPv6 + a disallowed port returns `false` *before* resolving
+      // `ip6tables`, proving the address itself passed validation.
+      var ok = await driver.acceptAddressOnTCPPort('2001:db8::1', 22,
+          allowedPorts: {99}, allowAllPorts: false);
+      expect(ok, isFalse);
+    });
+
+    test('acceptAddressOnTCPPort: disallowed port returns false', () async {
+      var ok = await driver.acceptAddressOnTCPPort('1.2.3.4', 22,
+          allowedPorts: {99}, allowAllPorts: false);
+      expect(ok, isFalse);
+    });
+
+    test('blockTCPPort: invalid port throws', () {
+      expect(
+        () => driver.blockTCPPort(5, allowedPorts: null, allowAllPorts: true),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('blockTCPPort: disallowed port returns false', () async {
+      var ok = await driver.blockTCPPort(22,
+          allowedPorts: {99}, allowAllPorts: false);
+      expect(ok, isFalse);
+    });
+
+    test('unblockTCPPort: invalid port throws', () {
+      expect(
+        () => driver.unblockTCPPort(5, allowedPorts: null, allowAllPorts: true),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+  });
+}

--- a/test/gatekeeper_ipv6_test.dart
+++ b/test/gatekeeper_ipv6_test.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:gatekeeper/gatekeeper.dart';
 import 'package:gatekeeper/src/gatekeeper_mock.dart';
 import 'package:gatekeeper/src/utils.dart';
@@ -21,6 +23,14 @@ void main() {
 
     test('trims whitespace', () {
       expect(normalizeIpAddress('  1.2.3.4  '), equals('1.2.3.4'));
+    });
+
+    test('empty stays empty', () {
+      expect(normalizeIpAddress('   '), equals(''));
+    });
+
+    test('non-mapped IPv6 containing ffff is unchanged', () {
+      expect(normalizeIpAddress('2001:ffff::1'), equals('2001:ffff::1'));
     });
   });
 
@@ -62,6 +72,21 @@ void main() {
           await gatekeeper.unacceptAddressOnTCPPort('2001:db8::1', 22), isTrue);
       expect(await gatekeeper.listAcceptedAddressesOnTCPPorts(),
           equals({(address: '1.2.3.4', port: 22)}));
+    });
+  });
+
+  group('Uint8ListExtension.merge', () {
+    test('merges two buffers', () {
+      var a = Uint8List.fromList([1, 2, 3]);
+      var b = Uint8List.fromList([4, 5]);
+      expect(a.merge(b), equals(Uint8List.fromList([1, 2, 3, 4, 5])));
+    });
+
+    test('merging with empty returns the other side', () {
+      var a = Uint8List.fromList([1, 2, 3]);
+      var empty = Uint8List(0);
+      expect(a.merge(empty), equals(a));
+      expect(empty.merge(a), equals(a));
     });
   });
 }

--- a/test/gatekeeper_ipv6_test.dart
+++ b/test/gatekeeper_ipv6_test.dart
@@ -1,0 +1,67 @@
+import 'package:gatekeeper/gatekeeper.dart';
+import 'package:gatekeeper/src/gatekeeper_mock.dart';
+import 'package:gatekeeper/src/utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('normalizeIpAddress', () {
+    test('IPv4-mapped IPv6 -> IPv4', () {
+      expect(normalizeIpAddress('::ffff:1.2.3.4'), equals('1.2.3.4'));
+      expect(normalizeIpAddress('::FFFF:10.0.0.1'), equals('10.0.0.1'));
+    });
+
+    test('plain IPv4 unchanged', () {
+      expect(normalizeIpAddress('192.168.0.1'), equals('192.168.0.1'));
+    });
+
+    test('plain IPv6 unchanged', () {
+      expect(normalizeIpAddress('2001:db8::1'), equals('2001:db8::1'));
+      expect(normalizeIpAddress('::1'), equals('::1'));
+    });
+
+    test('trims whitespace', () {
+      expect(normalizeIpAddress('  1.2.3.4  '), equals('1.2.3.4'));
+    });
+  });
+
+  group('isIPv6Address', () {
+    test('IPv6', () {
+      expect(isIPv6Address('2001:db8::1'), isTrue);
+      expect(isIPv6Address('::1'), isTrue);
+    });
+
+    test('IPv4', () {
+      expect(isIPv6Address('1.2.3.4'), isFalse);
+    });
+
+    test('IPv4-mapped (already normalized) treated as IPv4', () {
+      expect(isIPv6Address(normalizeIpAddress('::ffff:1.2.3.4')), isFalse);
+    });
+  });
+
+  group('Gatekeeper accept (family-agnostic via mock)', () {
+    test('accept and list IPv4 and IPv6 addresses', () async {
+      var gatekeeper =
+          Gatekeeper(driver: GatekeeperMock(), allowAllPorts: true);
+
+      expect(await gatekeeper.listAcceptedAddressesOnTCPPorts(),
+          equals(<({String address, int port})>{}));
+
+      expect(await gatekeeper.acceptAddressOnTCPPort('1.2.3.4', 22), isTrue);
+      expect(
+          await gatekeeper.acceptAddressOnTCPPort('2001:db8::1', 22), isTrue);
+
+      expect(
+          await gatekeeper.listAcceptedAddressesOnTCPPorts(),
+          equals({
+            (address: '1.2.3.4', port: 22),
+            (address: '2001:db8::1', port: 22),
+          }));
+
+      expect(
+          await gatekeeper.unacceptAddressOnTCPPort('2001:db8::1', 22), isTrue);
+      expect(await gatekeeper.listAcceptedAddressesOnTCPPorts(),
+          equals({(address: '1.2.3.4', port: 22)}));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds IPv6 / dual-stack support across the server, firewall driver, and client, plus a `help` command.

- **Server** (`gatekeeper_server.dart`): binds `InternetAddress.anyIPv6` with `v6Only: false` by default, so a single socket accepts both IPv4 and IPv6 connections. IPv4-mapped IPv6 remote addresses (`::ffff:1.2.3.4`) are normalized to plain IPv4.
- **Firewall driver** (`gatekeeper_iptables.dart`): manages IPv6 rules via `ip6tables` (optional — skipped gracefully when absent):
  - `accept`/`unaccept` select `iptables` vs `ip6tables` from the address family.
  - `block`/`unblock` apply to **both** families (so IPv6 traffic to a port is actually filtered).
  - Listings merge results from both tables.
- **Client** (`gatekeeper_client.dart`):
  - `accept . <port>` now whitelists **both** the client's IPv4 and IPv6 addresses. The current control connection reveals one family; the other is discovered via a short-lived auxiliary connection forced to that family (same access key, `myip`). It then prints the concrete IP(s) accepted. `unaccept .` removes both.
  - New `help` / `?` command listing every command and its usage.
  - `connect({addressType})` to force an IP family; new `myIPs()` returning both families.
- **utils**: `normalizeIpAddress` / `isIPv6Address` helpers.
- Version bumped to **1.1.0**.

## Notes

- For end-to-end IPv6 to work, the gatekeeper host must be reachable over both IPv4 and IPv6; if a family is unreachable (or the host is a literal single-family IP), that slot is simply skipped.
- `ip6tables` is optional; hosts without it keep working for IPv4.

## Testing

- `dart analyze` (lib/bin/test): clean.
- `dart test`: all pass, including the secure client/server integration test over the new dual-stack bind.
- Added `test/gatekeeper_ipv6_test.dart` covering `normalizeIpAddress`, `isIPv6Address`, and IPv4+IPv6 accept/list/unaccept via the mock driver.
- Full firewall (`iptables`/`ip6tables`) verification requires a Linux host with sudo (the macOS dev box has neither).

🤖 Generated with [Claude Code](https://claude.com/claude-code)